### PR TITLE
feat: add user registration & secure login flow

### DIFF
--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -16,7 +16,8 @@ def init_schema(db_path: Path = DB_PATH) -> None:
         with get_connection(db_path) as conn:
             create_tables(conn)
             # Create default admin user with password 'admin'
+            pwd_hash, salt = hash_password("admin")
             conn.execute(
                 "INSERT INTO users (username, password) VALUES (?, ?)",
-                ("admin", hash_password("admin")),
+                ("admin", f"{pwd_hash}:{salt}"),
             )

--- a/src/utils/security.py
+++ b/src/utils/security.py
@@ -6,16 +6,14 @@ import hashlib
 import os
 
 
-def hash_password(pwd: str) -> str:
-    """Hash password with SHA-256 and a 16-byte salt."""
-    salt = os.urandom(16)
-    hashed = hashlib.sha256(salt + pwd.encode()).hexdigest()
-    return salt.hex() + hashed
+def hash_password(pwd: str) -> tuple[str, str]:
+    """Return SHA-256 hash and hex salt for ``pwd``."""
+    salt = os.urandom(16).hex()
+    pwd_hash = hashlib.sha256(bytes.fromhex(salt) + pwd.encode()).hexdigest()
+    return pwd_hash, salt
 
 
-def verify_password(pwd: str, hashed: str) -> bool:
-    """Verify a password against the hashed value."""
-    salt = bytes.fromhex(hashed[:32])
-    stored_hash = hashed[32:]
-    new_hash = hashlib.sha256(salt + pwd.encode()).hexdigest()
-    return new_hash == stored_hash
+def verify_password(pwd: str, pwd_hash: str, salt: str) -> bool:
+    """Verify ``pwd`` against stored hash and salt."""
+    new_hash = hashlib.sha256(bytes.fromhex(salt) + pwd.encode()).hexdigest()
+    return new_hash == pwd_hash

--- a/src/windows/registration_window.py
+++ b/src/windows/registration_window.py
@@ -1,0 +1,62 @@
+"""User registration dialog."""
+
+from __future__ import annotations
+
+from PyQt5.QtWidgets import (
+    QDialog,
+    QFormLayout,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+)
+
+from ..database.models import create_user, user_exists
+from ..utils.validators import not_empty
+
+
+class RegistrationWindow(QDialog):
+    """Dialog to create a new user account."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Register")
+        self.username = QLineEdit()
+        self.password = QLineEdit()
+        self.password.setEchoMode(QLineEdit.Password)
+        self.confirm = QLineEdit()
+        self.confirm.setEchoMode(QLineEdit.Password)
+        register_btn = QPushButton("Register")
+        register_btn.clicked.connect(self.register)
+        self.confirm.returnPressed.connect(self.register)
+
+        layout = QFormLayout(self)
+        layout.addRow("Username", self.username)
+        layout.addRow("Password", self.password)
+        layout.addRow("Confirm", self.confirm)
+        layout.addRow(register_btn)
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        self.username.setFocus()
+
+    def register(self) -> None:
+        username = self.username.text()
+        pwd = self.password.text()
+        confirm = self.confirm.text()
+        if not not_empty(username):
+            QMessageBox.warning(self, "Error", "Username required")
+            return
+        if user_exists(username):
+            QMessageBox.warning(self, "Error", "Username already exists")
+            return
+        if pwd != confirm:
+            QMessageBox.warning(self, "Error", "Passwords do not match")
+            return
+        if len(pwd) < 6:
+            QMessageBox.warning(self, "Error", "Password must be at least 6 characters")
+            return
+        if create_user(username, pwd):
+            QMessageBox.information(self, "Success", "Account created")
+            self.accept()
+        else:
+            QMessageBox.warning(self, "Error", "Could not create user")

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,10 +1,27 @@
 """Security utils tests."""
 
+from src.database import database_manager
+from src.database.models import create_tables, create_user, user_exists
 from src.utils.security import hash_password, verify_password
 
 
 def test_hash_verify_roundtrip():
     pwd = "secret"
-    hashed = hash_password(pwd)
-    assert verify_password(pwd, hashed)
-    assert not verify_password("wrong", hashed)
+    pwd_hash, salt = hash_password(pwd)
+    assert verify_password(pwd, pwd_hash, salt)
+    assert not verify_password("wrong", pwd_hash, salt)
+
+
+def test_create_user_and_verify(tmp_path, monkeypatch):
+    db = tmp_path / "users.db"
+    monkeypatch.setattr(database_manager, "DB_PATH", db)
+    with database_manager.get_connection(db) as conn:
+        create_tables(conn)
+    assert create_user("alice", "pass123")
+    assert user_exists("alice")
+    with database_manager.get_connection(db) as conn:
+        row = conn.execute(
+            "SELECT password FROM users WHERE username='alice'"
+        ).fetchone()
+    stored_hash, salt = row[0].split(":")
+    assert verify_password("pass123", stored_hash, salt)


### PR DESCRIPTION
## Summary
- implement password hashing helpers returning hash and salt
- add user creation helpers to database layer
- enable registration dialog and integrate with login window
- adapt settings window and migrations to new hashing
- extend tests for new registration workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68798d2d4f108330850ad51c8bebf814