### PR TITLE
Remove unused imports

### DIFF
--- a/src/windows/patient_list_window.py
+++ b/src/windows/patient_list_window.py
@@ -4,14 +4,7 @@ from __future__ import annotations
 
 from PyQt5 import QtGui
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import (
-    QHBoxLayout,
-    QLineEdit,
-    QTableView,
-    QVBoxLayout,
-    QWidget,
-)
+from PyQt5.QtWidgets import QLineEdit, QTableView, QVBoxLayout, QWidget
 
 from ..database.database_manager import get_connection
 


### PR DESCRIPTION
## Summary
- remove unused `QIcon` and `QHBoxLayout` imports from the patient list window

## Testing
- `isort src/windows/patient_list_window.py`
- `black src/windows/patient_list_window.py`
- `isort .`
- `black .`


------
https://chatgpt.com/codex/tasks/task_e_687993604e3483308f0bc091919be78f