### PR TITLE
Extend patient schema and edit UI

### DIFF
--- a/src/database/models.py
+++ b/src/database/models.py
@@ -17,26 +17,37 @@ def create_tables(conn: sqlite3.Connection) -> None:
 
         CREATE TABLE IF NOT EXISTS patients (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
+            serial_no TEXT UNIQUE,
             name TEXT NOT NULL,
             age INTEGER,
-            gender TEXT,
-            contact TEXT
+            sex TEXT,
+            phone TEXT,
+            marital_status TEXT,
+            chief_complaint TEXT,
+            medical_history TEXT,
+            drug_taken TEXT,
+            created_date TEXT DEFAULT CURRENT_TIMESTAMP,
+            last_modified TEXT DEFAULT CURRENT_TIMESTAMP,
+            created_by TEXT
         );
 
         CREATE TABLE IF NOT EXISTS visits (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             patient_id INTEGER NOT NULL,
             visit_date TEXT NOT NULL,
-            treatment TEXT,
-            next_visit TEXT,
+            visit_details TEXT,
+            treatment_performed TEXT,
+            next_appointment TEXT,
             FOREIGN KEY(patient_id) REFERENCES patients(id) ON DELETE CASCADE
         );
 
         CREATE TABLE IF NOT EXISTS patient_files (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             patient_id INTEGER NOT NULL,
-            file_path TEXT NOT NULL,
             file_type TEXT,
+            file_name TEXT,
+            file_path TEXT NOT NULL,
+            upload_date TEXT DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY(patient_id) REFERENCES patients(id) ON DELETE CASCADE
         );
         """

--- a/src/windows/patient_entry_window.py
+++ b/src/windows/patient_entry_window.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from PyQt5.QtWidgets import (
+    QComboBox,
     QDialog,
     QFormLayout,
     QLineEdit,
     QPushButton,
+    QTextEdit,
 )
 
 from ..database.database_manager import get_connection
@@ -20,18 +22,32 @@ class PatientEntryWindow(QDialog):
     def __init__(self, parent=None, patient_id: int | None = None):
         super().__init__(parent)
         self.patient_id = patient_id
+        self.serial_edit = QLineEdit()
         self.name_edit = QLineEdit()
         self.age_edit = QLineEdit()
-        self.contact_edit = QLineEdit()
+        self.sex_combo = QComboBox()
+        self.sex_combo.addItems(["Male", "Female"])
+        self.phone_edit = QLineEdit()
+        self.marital_combo = QComboBox()
+        self.marital_combo.addItems(["Single", "Married"])
+        self.chief_edit = QTextEdit()
+        self.med_history_edit = QTextEdit()
+        self.drugs_edit = QTextEdit()
         save_btn = QPushButton("Save")
         save_btn.clicked.connect(self.save)
         visit_btn = QPushButton("Add Visit")
         visit_btn.clicked.connect(self.add_visit)
 
         layout = QFormLayout(self)
+        layout.addRow("Serial No.", self.serial_edit)
         layout.addRow("Name", self.name_edit)
         layout.addRow("Age", self.age_edit)
-        layout.addRow("Contact", self.contact_edit)
+        layout.addRow("Sex", self.sex_combo)
+        layout.addRow("Phone", self.phone_edit)
+        layout.addRow("Marital Status", self.marital_combo)
+        layout.addRow("Chief Complaint", self.chief_edit)
+        layout.addRow("Medical History", self.med_history_edit)
+        layout.addRow("Drugs Taken", self.drugs_edit)
         layout.addRow(save_btn, visit_btn)
 
         if patient_id:
@@ -40,29 +56,81 @@ class PatientEntryWindow(QDialog):
     def load_patient(self) -> None:
         with get_connection() as conn:
             row = conn.execute(
-                "SELECT name, age, contact FROM patients WHERE id=?", (self.patient_id,)
+                "SELECT serial_no, name, age, sex, phone, marital_status, chief_complaint, medical_history, drug_taken FROM patients WHERE id=?",
+                (self.patient_id,),
             ).fetchone()
             if row:
-                self.name_edit.setText(row[0])
-                self.age_edit.setText(str(row[1] or ""))
-                self.contact_edit.setText(row[2] or "")
+                (
+                    serial_no,
+                    name,
+                    age,
+                    sex,
+                    phone,
+                    marital_status,
+                    chief,
+                    med_hist,
+                    drugs,
+                ) = row
+                self.serial_edit.setText(serial_no or "")
+                self.name_edit.setText(name)
+                self.age_edit.setText(str(age or ""))
+                if sex:
+                    idx = self.sex_combo.findText(sex)
+                    if idx >= 0:
+                        self.sex_combo.setCurrentIndex(idx)
+                self.phone_edit.setText(phone or "")
+                if marital_status:
+                    idx = self.marital_combo.findText(marital_status)
+                    if idx >= 0:
+                        self.marital_combo.setCurrentIndex(idx)
+                self.chief_edit.setPlainText(chief or "")
+                self.med_history_edit.setPlainText(med_hist or "")
+                self.drugs_edit.setPlainText(drugs or "")
 
     def save(self) -> None:
         name = self.name_edit.text()
         if not not_empty(name):
             return
         age = self.age_edit.text() or None
-        contact = self.contact_edit.text()
+        serial_no = self.serial_edit.text() or None
+        sex = self.sex_combo.currentText()
+        phone = self.phone_edit.text()
+        marital = self.marital_combo.currentText()
+        chief = self.chief_edit.toPlainText()
+        med_hist = self.med_history_edit.toPlainText()
+        drugs = self.drugs_edit.toPlainText()
         with get_connection() as conn:
             if self.patient_id:
                 conn.execute(
-                    "UPDATE patients SET name=?, age=?, contact=? WHERE id=?",
-                    (name, age, contact, self.patient_id),
+                    "UPDATE patients SET serial_no=?, name=?, age=?, sex=?, phone=?, marital_status=?, chief_complaint=?, medical_history=?, drug_taken=?, last_modified=CURRENT_TIMESTAMP WHERE id=?",
+                    (
+                        serial_no,
+                        name,
+                        age,
+                        sex,
+                        phone,
+                        marital,
+                        chief,
+                        med_hist,
+                        drugs,
+                        self.patient_id,
+                    ),
                 )
             else:
                 cur = conn.execute(
-                    "INSERT INTO patients (name, age, contact) VALUES (?, ?, ?)",
-                    (name, age, contact),
+                    "INSERT INTO patients (serial_no, name, age, sex, phone, marital_status, chief_complaint, medical_history, drug_taken, created_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        serial_no,
+                        name,
+                        age,
+                        sex,
+                        phone,
+                        marital,
+                        chief,
+                        med_hist,
+                        drugs,
+                        "admin",
+                    ),
                 )
                 self.patient_id = cur.lastrowid
         self.accept()

--- a/src/windows/visit_dialog.py
+++ b/src/windows/visit_dialog.py
@@ -9,6 +9,7 @@ from PyQt5.QtWidgets import (
     QFormLayout,
     QLineEdit,
     QPushButton,
+    QTextEdit,
 )
 
 from ..database.database_manager import get_connection
@@ -23,6 +24,7 @@ class VisitDialog(QDialog):
         self.date_edit = QDateEdit()
         self.date_edit.setCalendarPopup(True)
         self.date_edit.setDate(QDate.currentDate())
+        self.details_edit = QTextEdit()
         self.treatment_edit = QLineEdit()
         self.next_date_edit = QDateEdit()
         self.next_date_edit.setCalendarPopup(True)
@@ -31,6 +33,7 @@ class VisitDialog(QDialog):
 
         layout = QFormLayout(self)
         layout.addRow("Date", self.date_edit)
+        layout.addRow("Details", self.details_edit)
         layout.addRow("Treatment", self.treatment_edit)
         layout.addRow("Next", self.next_date_edit)
         layout.addRow(save_btn)
@@ -38,10 +41,11 @@ class VisitDialog(QDialog):
     def save(self) -> None:
         with get_connection() as conn:
             conn.execute(
-                "INSERT INTO visits (patient_id, visit_date, treatment, next_visit) VALUES (?, ?, ?, ?)",
+                "INSERT INTO visits (patient_id, visit_date, visit_details, treatment_performed, next_appointment) VALUES (?, ?, ?, ?, ?)",
                 (
                     self.patient_id,
                     self.date_edit.date().toString("yyyy-MM-dd"),
+                    self.details_edit.toPlainText(),
                     self.treatment_edit.text(),
                     self.next_date_edit.date().toString("yyyy-MM-dd"),
                 ),


### PR DESCRIPTION
## Summary
- expand database schema with new patient fields
- support extended patient info in entry dialog
- add multiline visit details
- allow editing patients from list view

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ad43f14848330bee1d3fe1f03b73e