### PR TITLE
Add modular page classes

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -3,36 +3,16 @@
 from __future__ import annotations
 
 from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import (
-    QHBoxLayout,
-    QLabel,
-    QMainWindow,
-    QStackedWidget,
-    QVBoxLayout,
-    QWidget,
-)
+from PyQt5.QtWidgets import QHBoxLayout, QMainWindow, QStackedWidget, QWidget
 
 from ..widgets.sidebar import Sidebar
-from .pages.dashboard_page import DashboardPage
-from .patient_list_window import PatientListWindow as PatientListPage
-
-
-class VisitsPage(QWidget):
-    def __init__(self) -> None:
-        super().__init__()
-        QVBoxLayout(self).addWidget(QLabel("Visits Page"))
-
-
-class ReportsPage(QWidget):
-    def __init__(self) -> None:
-        super().__init__()
-        QVBoxLayout(self).addWidget(QLabel("Reports Page"))
-
-
-class SettingsPage(QWidget):
-    def __init__(self) -> None:
-        super().__init__()
-        QVBoxLayout(self).addWidget(QLabel("Settings Page"))
+from .pages import (
+    DashboardPage,
+    PatientListPage,
+    ReportsPage,
+    SettingsPage,
+    VisitsPage,
+)
 
 
 class MainWindow(QMainWindow):

--- a/src/windows/pages/__init__.py
+++ b/src/windows/pages/__init__.py
@@ -1,0 +1,15 @@
+from .dashboard_page import DashboardPage
+from .patient_entry_page import PatientEntryPage
+from .patient_list_page import PatientListPage
+from .visits_page import VisitsPage
+from .reports_page import ReportsPage
+from .settings_page import SettingsPage
+
+__all__ = [
+    "DashboardPage",
+    "PatientEntryPage",
+    "PatientListPage",
+    "VisitsPage",
+    "ReportsPage",
+    "SettingsPage",
+]

--- a/src/windows/pages/patient_entry_page.py
+++ b/src/windows/pages/patient_entry_page.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from PyQt5.QtWidgets import (
+    QComboBox,
+    QFormLayout,
+    QHBoxLayout,
+    QLineEdit,
+    QPushButton,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ...database.database_manager import get_connection
+from ...utils.validators import not_empty
+from ..visit_dialog import VisitDialog
+
+
+class PatientEntryPage(QWidget):
+    """Page to add or edit a patient."""
+
+    def __init__(
+        self, patient_id: int | None = None, parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self.patient_id = patient_id
+        layout = QVBoxLayout(self)
+
+        form = QFormLayout()
+        self.serial_edit = QLineEdit()
+        self.name_edit = QLineEdit()
+        self.age_edit = QLineEdit()
+        self.sex_combo = QComboBox()
+        self.sex_combo.addItems(["Male", "Female"])
+        self.phone_edit = QLineEdit()
+        self.marital_combo = QComboBox()
+        self.marital_combo.addItems(["Single", "Married"])
+        self.chief_edit = QTextEdit()
+        self.med_history_edit = QTextEdit()
+        self.drugs_edit = QTextEdit()
+
+        form.addRow("Serial No.", self.serial_edit)
+        form.addRow("Name", self.name_edit)
+        form.addRow("Age", self.age_edit)
+        form.addRow("Sex", self.sex_combo)
+        form.addRow("Phone", self.phone_edit)
+        form.addRow("Marital Status", self.marital_combo)
+        form.addRow("Chief Complaint", self.chief_edit)
+        form.addRow("Medical History", self.med_history_edit)
+        form.addRow("Drugs Taken", self.drugs_edit)
+        layout.addLayout(form)
+
+        btn_row = QHBoxLayout()
+        save_btn = QPushButton("Save")
+        save_btn.clicked.connect(self.save)
+        visit_btn = QPushButton("Add Visit")
+        visit_btn.clicked.connect(self.add_visit)
+        btn_row.addWidget(save_btn)
+        btn_row.addWidget(visit_btn)
+        layout.addLayout(btn_row)
+
+        if patient_id:
+            self.load_patient()
+
+    def load_patient(self) -> None:
+        with get_connection() as conn:
+            row = conn.execute(
+                "SELECT serial_no, name, age, sex, phone, marital_status, chief_complaint, medical_history, drug_taken FROM patients WHERE id=?",
+                (self.patient_id,),
+            ).fetchone()
+        if row:
+            (
+                serial_no,
+                name,
+                age,
+                sex,
+                phone,
+                marital_status,
+                chief,
+                med_hist,
+                drugs,
+            ) = row
+            self.serial_edit.setText(serial_no or "")
+            self.name_edit.setText(name)
+            self.age_edit.setText(str(age or ""))
+            if sex:
+                idx = self.sex_combo.findText(sex)
+                if idx >= 0:
+                    self.sex_combo.setCurrentIndex(idx)
+            self.phone_edit.setText(phone or "")
+            if marital_status:
+                idx = self.marital_combo.findText(marital_status)
+                if idx >= 0:
+                    self.marital_combo.setCurrentIndex(idx)
+            self.chief_edit.setPlainText(chief or "")
+            self.med_history_edit.setPlainText(med_hist or "")
+            self.drugs_edit.setPlainText(drugs or "")
+
+    def save(self) -> None:
+        name = self.name_edit.text()
+        if not not_empty(name):
+            return
+        age = self.age_edit.text() or None
+        serial_no = self.serial_edit.text() or None
+        sex = self.sex_combo.currentText()
+        phone = self.phone_edit.text()
+        marital = self.marital_combo.currentText()
+        chief = self.chief_edit.toPlainText()
+        med_hist = self.med_history_edit.toPlainText()
+        drugs = self.drugs_edit.toPlainText()
+        with get_connection() as conn:
+            if self.patient_id:
+                conn.execute(
+                    "UPDATE patients SET serial_no=?, name=?, age=?, sex=?, phone=?, marital_status=?, chief_complaint=?, medical_history=?, drug_taken=?, last_modified=CURRENT_TIMESTAMP WHERE id=?",
+                    (
+                        serial_no,
+                        name,
+                        age,
+                        sex,
+                        phone,
+                        marital,
+                        chief,
+                        med_hist,
+                        drugs,
+                        self.patient_id,
+                    ),
+                )
+            else:
+                cur = conn.execute(
+                    "INSERT INTO patients (serial_no, name, age, sex, phone, marital_status, chief_complaint, medical_history, drug_taken, created_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        serial_no,
+                        name,
+                        age,
+                        sex,
+                        phone,
+                        marital,
+                        chief,
+                        med_hist,
+                        drugs,
+                        "admin",
+                    ),
+                )
+                self.patient_id = cur.lastrowid
+
+    def add_visit(self) -> None:
+        if not self.patient_id:
+            self.save()
+        if self.patient_id:
+            VisitDialog(self.patient_id, self).exec_()

--- a/src/windows/pages/patient_list_page.py
+++ b/src/windows/pages/patient_list_page.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from PyQt5 import QtGui
+from PyQt5.QtWidgets import QLineEdit, QTableView, QVBoxLayout, QWidget
+
+from ..patient_entry_window import PatientEntryWindow
+from ...database.database_manager import get_connection
+
+
+class PatientListPage(QWidget):
+    """Page listing patients in a table."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        self.search = QLineEdit()
+        self.table = QTableView()
+        self.table.doubleClicked.connect(self.edit_selected)
+        layout.addWidget(self.search)
+        layout.addWidget(self.table)
+        self.load()
+
+    def load(self) -> None:
+        with get_connection() as conn:
+            rows = conn.execute(
+                "SELECT id, serial_no, name, phone FROM patients ORDER BY serial_no"
+            ).fetchall()
+        model = QtGui.QStandardItemModel(len(rows), 4)
+        model.setHorizontalHeaderLabels(["ID", "Serial", "Name", "Phone"])
+        for row_idx, row in enumerate(rows):
+            for col_idx, value in enumerate(row):
+                item = QtGui.QStandardItem(str(value))
+                model.setItem(row_idx, col_idx, item)
+        self.table.setModel(model)
+
+    def edit_selected(self) -> None:
+        index = self.table.currentIndex()
+        if not index.isValid():
+            return
+        model = self.table.model()
+        patient_id = int(model.item(index.row(), 0).text())
+        dlg = PatientEntryWindow(self, patient_id)
+        dlg.exec_()
+        self.load()

--- a/src/windows/pages/reports_page.py
+++ b/src/windows/pages/reports_page.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from PyQt5.QtWidgets import QLabel, QVBoxLayout, QWidget
+
+
+class ReportsPage(QWidget):
+    """Placeholder page for reports."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Reports Page"))

--- a/src/windows/pages/settings_page.py
+++ b/src/windows/pages/settings_page.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from PyQt5.QtWidgets import QFormLayout, QLineEdit, QMessageBox, QPushButton, QWidget
+
+from ...database.database_manager import get_connection
+from ...utils.security import hash_password, verify_password
+
+
+class SettingsPage(QWidget):
+    """Page to change password."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        form = QFormLayout(self)
+        self.old_pwd = QLineEdit()
+        self.old_pwd.setEchoMode(QLineEdit.Password)
+        self.new_pwd = QLineEdit()
+        self.new_pwd.setEchoMode(QLineEdit.Password)
+        change_btn = QPushButton("Change Password")
+        change_btn.clicked.connect(self.change_password)
+        form.addRow("Old Password", self.old_pwd)
+        form.addRow("New Password", self.new_pwd)
+        form.addRow(change_btn)
+
+    def change_password(self) -> None:
+        with get_connection() as conn:
+            row = conn.execute(
+                "SELECT password FROM users WHERE username='admin'"
+            ).fetchone()
+        if row:
+            stored_hash, salt = row[0].split(":")
+            if verify_password(self.old_pwd.text(), stored_hash, salt):
+                new_hash, new_salt = hash_password(self.new_pwd.text())
+                with get_connection() as conn:
+                    conn.execute(
+                        "UPDATE users SET password=? WHERE username='admin'",
+                        (f"{new_hash}:{new_salt}",),
+                    )
+                QMessageBox.information(self, "Success", "Password changed")
+                return
+        QMessageBox.warning(self, "Error", "Old password incorrect")

--- a/src/windows/pages/visits_page.py
+++ b/src/windows/pages/visits_page.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from PyQt5.QtWidgets import QLabel, QVBoxLayout, QWidget
+
+
+class VisitsPage(QWidget):
+    """Placeholder page for visit logs."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Visits Page"))


### PR DESCRIPTION
## Summary
- modernize the main window to load pages from a dedicated package
- provide new page classes for patient lists, entry, visits, reports and settings
- export the page classes via `pages/__init__.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687adb5cc60083309ee09a76097b7146